### PR TITLE
updated design of the block access layer

### DIFF
--- a/docs/Design/Block Access Layer.md
+++ b/docs/Design/Block Access Layer.md
@@ -600,12 +600,18 @@ int BlockAccess::deleteRelation(char relName[ATTR_SIZE]) {
     ***/
     // reset the searchIndex of the attribute catalog to {-1, -1} using RelCacheTable::setSearchIndex()
 
+    // store the number of attributes deleted, because in case all the attributes were not successfully
+    // added, we need to keep track of the deleted attributes
+    int numberOfAttributesDeleted = 0;
+
     while(true) {
         RecId attrCatRecId;
         // attrCatRecId = linearSearch on attribute catalog for RelName = relNameAttr
 
         // if no more attributes to iterate over (attrCatRecId == {-1, -1})
         //     break;
+
+        numberOfAttributesDeleted++;
 
         // create a RecBuffer for attrCatRecId.block
         // get the header of the block
@@ -662,7 +668,7 @@ int BlockAccess::deleteRelation(char relName[ATTR_SIZE]) {
     // Hint: Get the entry corresponding to relation catalog from the relation cache and update the number of records and set it back
 
     /** Update attribute catalog entry (number of records in attribute catalog is decreased by numberOfAttributesDeleted) **/
-    // i.e., #Records = #Records - numberOfAttributesOfRelation
+    // i.e., #Records = #Records - numberOfAttributesDeleted
 
     // Hint: Get the entry corresponding to attribute catalog from the relation cache and update the number of records and set it back
 

--- a/docs/Design/Block Access Layer.md
+++ b/docs/Design/Block Access Layer.md
@@ -50,14 +50,19 @@ public:
 #### Description
 
 This method searches the relation specified linearly to find the next record that satisfies the specified condition on attribute attrVal and returns the recId of the next record satisfying the condition.
+The function checks for
+
+```
+value-in-record `op` attrVal
+```
 
 #### Arguments
 
 | Name     | Type              | Description                                                                                                                                                                                                                                        |
 | -------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | relId    | `int`             | Relation Id of Relation to which search has to be made.                                                                                                                                                                                            |
-| attrName | `char[ATTR_SIZE]` | Attribute/column name to which condition need to be checked with.                                                                                                                                                                                  |
-| attrVal  | `union Attribute` | value of attribute that has to be checked against the operater.                                                                                                                                                                                    |
+| attrName | `char[ATTR_SIZE]` | Attribute/column name to which condition need to be checked against.                                                                                                                                                                               |
+| attrVal  | `union Attribute` | value of attribute that has to be checked against the value in the record.                                                                                                                                                                         |
 | op       | `int`             | The conditional operator (which can be one among `EQ, LE, LT, GE, GT, NE, RST, PRJCT` corresponding to the following operators: _equal to, less than or equal to, less than, greater than or equal to, greater than, not equal to, reset, project_ |
 
 #### Return Values
@@ -110,13 +115,13 @@ RecId BlockAccess::linearSearch(int relId, char attrName[ATTR_SIZE], union Attri
         {
             // update block = right block of block
             // update slot = 0
+            // continue to the next execution
         }
 
         // if slot is free skip the loop
         // (i.e. check if slot'th entry in slot map of block contains SLOT_UNOCCUPIED)
         {
-            // and continue to the next record slot
-            // (i.e. increment slot and continue)
+            // increment slot and continue to the next record slot
         }
 
         // let cond be a variable of int type
@@ -129,80 +134,44 @@ RecId BlockAccess::linearSearch(int relId, char attrName[ATTR_SIZE], union Attri
                 from the attribute cache entry of the relation using AttrCacheTable::getAttrCatEntry
             */
             // use the attribute offset to get the value of the attribute from current record
-            // perform comparison using compare function and store the outcome of comparison in the variable flag
 
-            // initialize cond = UNSET
+            int cmpVal;
+            // store the difference between the record's attribute value and attrVal in cmpVal
+            // If attribute is a STRING, use strcmp
+            // If attribute is a NUMBER, subtract the values
 
+            // set cond = UNSET
 
             // Next task is to check whether this record satisfies the given condition.
             // It is determined based on the output of previous comparison and the op value received.
             // The following code sets the cond variable if the condition is satisfied.
-            switch (op) {
-
-                case NE:
-                    // if op is "not equal to"
-                    // if the record's attribute value is not equal to the given attrVal
-                    if (flag != 0) {
-                        // SET the cond variable (i.e. cond = SET)
-                    }
-                    break;
-
-                case LT:
-                    // if op is "less than"
-                    // if the record's attribute value is less than the given attrVal
-                    if (flag < 0) {
-                        // SET the cond variable (i.e. cond = SET)
-                    }
-                    break;
-
-                case LE:
-                    // if op is "less than or equal to"
-                    // if the record's attribute value is less than or equal to the given attrVal
-                    if (flag <= 0) {
-                        // SET the cond variable (i.e. cond = SET)
-                    }
-                    break;
-
-                case EQ:
-                    // op is "equal to"
-                    // if the record's attribute value is equal to the given attrVal
-                    if (flag == 0) {
-                        // SET the cond variable (i.e. cond = SET)
-                    }
-                    break;
-
-                case GT:
-                    // if op is "greater than"
-                    // if the record's attribute value is greater than the given attrVal
-                    if (flag > 0) {
-                        // SET the cond variable (i.e. cond = SET)
-                    }
-                    break;
-
-                case GE:
-                    // if op is "greater than or equal to"
-                    // if the record's attribute value is greater than or equal to the given attrVal
-                    if (flag >= 0) {
-                        // SET the cond variable (i.e. cond = SET)
-                    }
-                    break;
+            if (
+                (op == NE && cmpVal != 0) ||    // if op is "not equal to"
+                (op == LT && cmpVal < 0) ||     // if op is "less than"
+                (op == LE && cmpVal <= 0) ||    // if op is "less than or equal to"
+                (op == EQ && cmpVal == 0) ||    // if op is "equal to"
+                (op == GT && cmpVal > 0) ||     // if op is "greater than"
+                (op == GE && cmpVal >= 0)       // if op is "greater than or equal to"
+            ) {
+                // SET the cond variable (i.e. cond = SET)
             }
         }
 
         if (cond == SET || op == PRJCT) {
             /*
-                set the search index in the relation cache as
-                the record id of the record that satisfies the given condition
-                (use RelCacheTable::setSearchIndex function)
+            set the search index in the relation cache as
+            the record id of the record that satisfies the given condition
+            (use RelCacheTable::setSearchIndex function)
             */
 
             return RecId{block, slot};
         }
 
+        slot++;
     }
 
     // no record in the relation with Id relid satisfies the given condition
-    return {-1, -1};
+    return RecId{-1, -1};
 }
 ```
 

--- a/docs/Design/Block Access Layer.md
+++ b/docs/Design/Block Access Layer.md
@@ -42,6 +42,8 @@ public:
 
     static RecId linearSearch(int relId, char attrName[ATTR_SIZE], Attribute attrVal, int op);
 
+    static int project(int relId, Attribute *record);
+
 };
 ```
 
@@ -58,12 +60,12 @@ value-in-record `op` attrVal
 
 #### Arguments
 
-| Name     | Type              | Description                                                                                                                                                                                                                                        |
-| -------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| relId    | `int`             | Relation Id of Relation to which search has to be made.                                                                                                                                                                                            |
-| attrName | `char[ATTR_SIZE]` | Attribute/column name to which condition need to be checked against.                                                                                                                                                                               |
-| attrVal  | `union Attribute` | value of attribute that has to be checked against the value in the record.                                                                                                                                                                         |
-| op       | `int`             | The conditional operator (which can be one among `EQ, LE, LT, GE, GT, NE, RST, PRJCT` corresponding to the following operators: _equal to, less than or equal to, less than, greater than or equal to, greater than, not equal to, reset, project_ |
+| Name     | Type              | Description                                                                                                                                                                                                            |
+| -------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| relId    | `int`             | Relation Id of Relation to which search has to be made.                                                                                                                                                                |
+| attrName | `char[ATTR_SIZE]` | Attribute/column name to which condition need to be checked against.                                                                                                                                                   |
+| attrVal  | `union Attribute` | value of attribute that has to be checked against the value in the record.                                                                                                                                             |
+| op       | `int`             | The conditional operator (which can be one among `EQ, LE, LT, GE, GT, NE` corresponding to the following operators: _equal to, less than or equal to, less than, greater than or equal to, greater than, not equal to_ |
 
 #### Return Values
 
@@ -115,7 +117,7 @@ RecId BlockAccess::linearSearch(int relId, char attrName[ATTR_SIZE], union Attri
         {
             // update block = right block of block
             // update slot = 0
-            // continue to the next execution
+            continue;  // continue to the beginning of this while loop
         }
 
         // if slot is free skip the loop
@@ -125,39 +127,38 @@ RecId BlockAccess::linearSearch(int relId, char attrName[ATTR_SIZE], union Attri
         }
 
         // let cond be a variable of int type
+        // it will store if the given condition is satisfied based on the comparison
 
-        if ( op != PRJCT )
-        {
-            // compare record's attribute value to the the given attrVal as below:
-            /*
-                firstly get the attribute offset for the attrName attribute
-                from the attribute cache entry of the relation using AttrCacheTable::getAttrCatEntry
-            */
-            // use the attribute offset to get the value of the attribute from current record
 
-            int cmpVal;
-            // store the difference between the record's attribute value and attrVal in cmpVal
+        // compare record's attribute value to the the given attrVal as below:
+        /*
+            firstly get the attribute offset for the attrName attribute
+            from the attribute cache entry of the relation using AttrCacheTable::getAttrCatEntry
+        */
+        // use the attribute offset to get the value of the attribute from current record
+
+        int cmpVal = // difference between the record's attribute value and attrVal
             // If attribute is a STRING, use strcmp
             // If attribute is a NUMBER, subtract the values
 
-            // set cond = UNSET
+        // set cond = UNSET
 
-            // Next task is to check whether this record satisfies the given condition.
-            // It is determined based on the output of previous comparison and the op value received.
-            // The following code sets the cond variable if the condition is satisfied.
-            if (
-                (op == NE && cmpVal != 0) ||    // if op is "not equal to"
-                (op == LT && cmpVal < 0) ||     // if op is "less than"
-                (op == LE && cmpVal <= 0) ||    // if op is "less than or equal to"
-                (op == EQ && cmpVal == 0) ||    // if op is "equal to"
-                (op == GT && cmpVal > 0) ||     // if op is "greater than"
-                (op == GE && cmpVal >= 0)       // if op is "greater than or equal to"
-            ) {
-                // SET the cond variable (i.e. cond = SET)
-            }
+        // Next task is to check whether this record satisfies the given condition.
+        // It is determined based on the output of previous comparison and the op value received.
+        // The following code sets the cond variable if the condition is satisfied.
+        if (
+            (op == NE && cmpVal != 0) ||    // if op is "not equal to"
+            (op == LT && cmpVal < 0) ||     // if op is "less than"
+            (op == LE && cmpVal <= 0) ||    // if op is "less than or equal to"
+            (op == EQ && cmpVal == 0) ||    // if op is "equal to"
+            (op == GT && cmpVal > 0) ||     // if op is "greater than"
+            (op == GE && cmpVal >= 0)       // if op is "greater than or equal to"
+        ) {
+            // SET the cond variable (i.e. cond = SET)
         }
 
-        if (cond == SET || op == PRJCT) {
+
+        if (cond == SET) {
             /*
             set the search index in the relation cache as
             the record id of the record that satisfies the given condition
@@ -183,13 +184,13 @@ This method searches the relation specified to find the next record that satisfi
 
 #### Arguments
 
-| Name     | Type               | Description                                                                                                                                                                                                                                       |
-| -------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| relId    | `int`              | Relation Id of Relation to which search has to be made.                                                                                                                                                                                           |
-| record   | `union Attribute*` | pointer to record where next found record satisfying given condition is to be placed.                                                                                                                                                             |
-| attrName | `char[ATTR_SIZE]`  | Attribute/column name to which condition need to be checked with.                                                                                                                                                                                 |
-| attrVal  | `union Attribute`  | value of attribute that has to be checked against the operater.                                                                                                                                                                                   |
-| op       | `int`              | Conditional Operator (can be one among `EQ` , `LE` , `LT` , `GE` , `GT` , `NE` , `RST` , `PRJCT` corresponding to equal, less or than equal, less than ,greater than or equal, greater than, not equal, reset and projet operators respectively). |
+| Name     | Type               | Description                                                                                                                                                                                                   |
+| -------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| relId    | `int`              | Relation Id of Relation to which search has to be made.                                                                                                                                                       |
+| record   | `union Attribute*` | pointer to record where next found record satisfying given condition is to be placed.                                                                                                                         |
+| attrName | `char[ATTR_SIZE]`  | Attribute/column name to which condition need to be checked with.                                                                                                                                             |
+| attrVal  | `union Attribute`  | value of attribute that has to be checked against the operater.                                                                                                                                               |
+| op       | `int`              | Conditional Operator (can be one among `EQ` , `LE` , `LT` , `GE` , `GT` , `NE` corresponding to equal, less or than equal, less than ,greater than or equal, greater than, not equal operators respectively). |
 
 #### Return Values
 
@@ -205,36 +206,23 @@ int BlockAccess::search(int relId, Attribute *record, char attrName[ATTR_SIZE], 
     // Declare a variable called recid to store the searched record
     RecId recId;
 
-    if (op == PRJCT){
-        // search for the next record id (recid) corresponding for the relation
-        // by passing op = PRJCT and dummy attrName, attrVal.
-        recId = linearSearch(relId, attrName, attrVal, op);
+    /* get the attribute catalog entry from the attribute cache corresponding
+    to the relation with Id=relid and with attribute_name=attrName  */
+
+    // get rootBlock from the attribute catalog entry
+    /* if Index does not exist for the attribute (check rootBlock == -1) */ {
+
+        // search for the record id (recid) corresponding to the attribute with attribute name attrName, with value attrval
+        // and satisfying the condition op using linearSearch()
     }
-    else if (op == RST){
-        /*
-        reset the searchIndex corresponding to the relation with id=relId in the
-        relation cache to {-1, -1}
-        */
-        return SUCCESS;
+
+    /* else */ {
+        // (index exists for the attribute)
+
+        // search for the record id (recid) correspoding to the attribute with attribute name attrName and with value attrval
+        // recid = bplus_search(relId, attrName, attval, op);
     }
-    else {
-        /* get the attribute catalog entry from the attribute cache corresponding
-        to the relation with Id=relid and with attribute_name=attrName  */
 
-        // get rootBlock from the attribute catalog entry
-        /* if Index does not exist for the attribute (check rootBlock == -1) */ {
-
-            // search for the record id (recid) corresponding to the attribute with attribute name attrName, with value attrval
-            // and satisfying the condition op using linearSearch()
-        }
-
-        /* else */ {
-            // (index exists for the attribute)
-
-            // search for the record id (recid) correspoding to the attribute with attribute name attrName and with value attrval
-            // recid = bplus_search(relId, attrName, attval, op);
-        }
-    }
 
     // if it fails to find a record satisfying the given condition (recId = {-1, -1}) return E_NOTFOUND;
 
@@ -425,7 +413,7 @@ This method changes the relation name of specified relation to the new name spec
 
 ```cpp
 int BlockAccess::renameRelation(char oldName[ATTR_SIZE], char newName[ATTR_SIZE]){
-    // reset the searchIndex of the relation catalog to {-1, -1} using RelCacheTable::setSearchIndex()
+    // reset the searchIndex of the relation catalog using RelCacheTable::resetSearchIndex()
 
     Attribute newRelationName;
 
@@ -435,7 +423,7 @@ int BlockAccess::renameRelation(char oldName[ATTR_SIZE], char newName[ATTR_SIZE]
     //    return E_RELEXIST;
 
 
-    // reset the searchIndex of the relation catalog to {-1, -1} using RelCacheTable::setSearchIndex()
+    // reset the searchIndex of the relation catalog using RelCacheTable::resetSearchIndex()
 
     Attribute oldRelationName;
 
@@ -455,7 +443,7 @@ int BlockAccess::renameRelation(char oldName[ATTR_SIZE], char newName[ATTR_SIZE]
     to the relation with relation name oldName to the relation name newName
     */
 
-    // reset the searchIndex of the attribute catalog to {-1, -1} using RelCacheTable::setSearchIndex()
+    // reset the searchIndex of the attribute catalog using RelCacheTable::resetSearchIndex()
 
     //for i = 0 to numberOfAttributes :
     //    linearSearch on the attribute catalog for relName = oldRelationName
@@ -496,7 +484,7 @@ This method changes the name of an attribute/column present in a specified relat
 ```cpp
 int BlockAccess::renameAttribute(char relName[ATTR_SIZE], char oldName[ATTR_SIZE], char newName[ATTR_SIZE]) {
 
-    // reset the searchIndex of the relation catalog to {-1, -1} using RelCacheTable::setSearchIndex()
+    // reset the searchIndex of the relation catalog using RelCacheTable::resetSearchIndex()
 
     Attribute relNameAttr;
 
@@ -507,7 +495,7 @@ int BlockAccess::renameAttribute(char relName[ATTR_SIZE], char oldName[ATTR_SIZE
     /***
         Iterating over all Attribute Catalog Entry record corresponding to relation to find the required attribute
     ***/
-    // reset the searchIndex of the attribute catalog to {-1, -1} using RelCacheTable::setSearchIndex()
+    // reset the searchIndex of the attribute catalog using RelCacheTable::resetSearchIndex()
 
     // declare attrToRenameRecId used to store the attr-cat recId of the attribute to rename
     RecId attrToRenameRecId{-1, -1};
@@ -570,7 +558,7 @@ If at any point getHeader(), setHeader(), getRecord(), setRecord(), getSlotMap()
 
 ```cpp
 int BlockAccess::deleteRelation(char relName[ATTR_SIZE]) {
-    // reset the searchIndex of the relation catalog to {-1, -1} using RelCacheTable::setSearchIndex()
+    // reset the searchIndex of the relation catalog using RelCacheTable::resetSearchIndex()
 
     Attribute relNameAttr;
 
@@ -598,7 +586,7 @@ int BlockAccess::deleteRelation(char relName[ATTR_SIZE]) {
     /***
         Deleting attribute catalog entries corresponding the relation and index blocks corresponding to the relation with relName on its attributes
     ***/
-    // reset the searchIndex of the attribute catalog to {-1, -1} using RelCacheTable::setSearchIndex()
+    // reset the searchIndex of the attribute catalog using RelCacheTable::resetSearchIndex()
 
     // store the number of attributes deleted, because in case all the attributes were not successfully
     // added, we need to keep track of the deleted attributes
@@ -671,6 +659,99 @@ int BlockAccess::deleteRelation(char relName[ATTR_SIZE]) {
     // i.e., #Records = #Records - numberOfAttributesDeleted
 
     // Hint: Get the entry corresponding to attribute catalog from the relation cache and update the number of records and set it back
+
+    return SUCCESS;
+}
+```
+
+### BlockAccess :: project()
+
+#### Description
+
+This method iterates over the relation specified to fetch the next record (until all records are fetched) and updates the recId of next record in cache.
+
+#### Arguments
+
+| Name   | Type               | Description                                                 |
+| ------ | ------------------ | ----------------------------------------------------------- |
+| relId  | `int`              | Relation Id of Relation to which projection has to be done. |
+| record | `union Attribute*` | pointer to record where next record is to be placed.        |
+
+#### Return Values
+
+| Value                      | Description                                                 |
+| -------------------------- | ----------------------------------------------------------- |
+| [`SUCCESS`](/constants)    | On successful copy of record to _record_                    |
+| [`E_NOTFOUND`](/constants) | If there are no more records to be fetched for the relation |
+
+#### Algorithm
+
+```cpp
+int BlockAccess::project(int relId, Attribute *record) {
+    // get the previous search index of the relation relId from the relation cache
+    // (use RelCacheTable::getSearchIndex() function)
+
+    // let block and slot denote the record id of the record being currently checked
+
+    // if the current search index record is invalid(i.e. both block and slot = -1)
+    if (prevRecId.block == -1 && prevRecId.slot == -1)
+    {
+        // (new project operation. start from beginning)
+
+        // get the first record block of the relation from the relation cache
+        // (use RelCacheTable::getRelCatEntry() function of Cache Layer)
+
+        // block = first record block of the relation
+        // slot = 0
+    }
+    else
+    {
+        // (a project operation is already in progress)
+
+        // block = previous search index's block
+        // slot = previous search index's slot + 1
+    }
+
+
+    // The following code finds the next record of the relation
+    // Start from the record id (block, slot) and iterate over the remaining records of the relation
+    while (block != -1)
+    {
+        // create a RecBuffer object for block (use RecBuffer Constructor for existing block)
+
+        // get header of the block using RecBuffer::getHeader() function
+        // get slot map of the block using RecBuffer::getSlotMap() function
+
+        if(/* slot >= the number of slots per block*/)
+        {
+            // (no more slots in this block)
+            // update block = right block of block
+            // update slot = 0
+        }
+        else if (/* slot is free (i.e slot-th entry in slotMap contains SLOT_UNOCCUPIED) */)
+        {
+            // increment slot
+        }
+        else {
+            // (the next occupied slot / record has been found)
+            break;
+        }
+    }
+
+    if (block == -1){
+        // (a record was not found. all records exhausted)
+        return E_NOTFOUND;
+    }
+
+    // declare nextRecId to store the RecId of the record found
+    RecId nextRecId{block, slot};
+
+    // set the search index to nextRecId using RelCacheTable::setSearchIndex
+
+    /* Copy the record with record id (nextRecId) to the record buffer (record)
+       For this Instantiate a RecBuffer class object by passing the recId and
+       call the appropriate method to fetch the record
+    */
 
     return SUCCESS;
 }

--- a/docs/Design/Block Access Layer.md
+++ b/docs/Design/Block Access Layer.md
@@ -183,14 +183,13 @@ This method searches the relation specified to find the next record that satisfi
 
 #### Arguments
 
-| Name              | Type               | Description                                                                                                                                                                                                                                                                 |
-| ----------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| relId             | `int`              | Relation Id of Relation to which search has to be made.                                                                                                                                                                                                                     |
-| record            | `union Attribute*` | pointer to record where next found record satisfying given condition is to be placed.                                                                                                                                                                                       |
-| attrName          | `char[ATTR_SIZE]`  | Attribute/column name to which condition need to be checked with.                                                                                                                                                                                                           |
-| attrVal           | `union Attribute`  | value of attribute that has to be checked against the operater.                                                                                                                                                                                                             |
-| op                | `int`              | Conditional Operator (can be one among `EQ` , `LE` , `LT` , `GE` , `GT` , `NE` , `RST` , `PRJCT` corresponding to equal, less or than equal, less than ,greater than or equal, greater than, not equal, reset and projet operators respectively).                           |
-| flagValidAttrName | `int`              | Specifies whether the attrName passed as argument is a valid one or not. For example, for resetting the search hit before doing a search using project operator, we will be required to pass dummy attrName (and a dummy attrVal) in which case this flag is set to `false` |
+| Name     | Type               | Description                                                                                                                                                                                                                                       |
+| -------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| relId    | `int`              | Relation Id of Relation to which search has to be made.                                                                                                                                                                                           |
+| record   | `union Attribute*` | pointer to record where next found record satisfying given condition is to be placed.                                                                                                                                                             |
+| attrName | `char[ATTR_SIZE]`  | Attribute/column name to which condition need to be checked with.                                                                                                                                                                                 |
+| attrVal  | `union Attribute`  | value of attribute that has to be checked against the operater.                                                                                                                                                                                   |
+| op       | `int`              | Conditional Operator (can be one among `EQ` , `LE` , `LT` , `GE` , `GT` , `NE` , `RST` , `PRJCT` corresponding to equal, less or than equal, less than ,greater than or equal, greater than, not equal, reset and projet operators respectively). |
 
 #### Return Values
 
@@ -202,60 +201,39 @@ This method searches the relation specified to find the next record that satisfi
 #### Algorithm
 
 ```cpp
-int BlockAccess::search(int relId, Attribute *record, char attrName[ATTR_SIZE], Attribute attrVal, int op, int flagValidAttrName) {
+int BlockAccess::search(int relId, Attribute *record, char attrName[ATTR_SIZE], Attribute attrVal, int op) {
     // Declare a variable called recid to store the searched record
     RecId recId;
 
-    // If op = PRJCT:
+    if (op == PRJCT){
         // search for the next record id (recid) corresponding for the relation
         // by passing op = PRJCT and dummy attrName, attrVal.
         recId = linearSearch(relId, attrName, attrVal, op);
-
-    // else {
-        // if (flagValidAttrName == false && op == RST):
-            // assign the previous record id (prevRecId) to {block_num=-1, slot_num=-1}
-
-            /* update the previous record id (prev_recid) in the relation cache entry
-             * corresponding to the relation with Id = relid by using method from the cache layer */
-
-
-            // return SUCCESS;
-        }
-
+    }
+    else if (op == RST){
+        /*
+        reset the searchIndex corresponding to the relation with id=relId in the
+        relation cache to {-1, -1}
+        */
+        return SUCCESS;
+    }
+    else {
         /* get the attribute catalog entry from the attribute cache corresponding
         to the relation with Id=relid and with attribute_name=attrName  */
 
-        // get rootBlock from the attribute catalog entry (attrcat_entry)
-        // if Index does not exist for the attribute (check rootBlock == -1)
-        // if (attrCatEntry.rootBlock == -1) :
-            // if the op is reset
-            if (op == RST) {
-                // assign the previous record id (prevRecId) to {block_num=-1, slot_num=-1}
-
-                /* update the previous record id (prev_recid) in the relation cache entry
-                 * corresponding to the relation with Id = relid by using method from the cache layer */
-
-                // return SUCCESS;
-            }
+        // get rootBlock from the attribute catalog entry
+        /* if Index does not exist for the attribute (check rootBlock == -1) */ {
 
             // search for the record id (recid) corresponding to the attribute with attribute name attrName, with value attrval
             // and satisfying the condition op using linearSearch()
+        }
 
-        // else:
-            // else Index exists for the attribute
-            // if (op == RST):
-                // assign the previous index id (prevIndexId variable) to {block_num=-1, index_num=-1}
-
-                /* update the previous index id (prev_recid) in the attribute cache corresponding
-                   to the relation with Id relid and attribute name with attrName
-                   using appropriate method of cache layer */
-
-
-                // return SUCCESS
+        /* else */ {
+            // (index exists for the attribute)
 
             // search for the record id (recid) correspoding to the attribute with attribute name attrName and with value attrval
-
             // recid = bplus_search(relId, attrName, attval, op);
+        }
     }
 
     // if it fails to find a record satisfying the given condition (recId = {-1, -1}) return E_NOTFOUND;
@@ -265,7 +243,7 @@ int BlockAccess::search(int relId, Attribute *record, char attrName[ATTR_SIZE], 
        call the appropriate method to fetch the record
     */
 
-    // return SUCCESS
+    return SUCCESS;
 }
 ```
 
@@ -325,7 +303,7 @@ int BlockAccess::insert(int relId, Attribute *record) {
 
         // if a free slot is found, discontinue the traversal of the linked list of record blocks
 
-        // otherwise, continue to check the next block by updating the block numebers as follows:
+        // otherwise, continue to check the next block by updating the block numbers as follows:
         // update prevBlockNum = blockNum
         // update blockNum = header.rblock (next element in the linked list of record blocks)
     }
@@ -341,7 +319,6 @@ int BlockAccess::insert(int relId, Attribute *record) {
         // (use BlockBuffer::getBlockNum() function)
         // let ret be the return value of getBlockNum() function call
         if (ret == E_DISKFULL) {
-            // disk is full
             return E_DISKFULL;
         }
 
@@ -398,8 +375,7 @@ int BlockAccess::insert(int relId, Attribute *record) {
     /*
         B+ tree insertions
      */
-    // Let flag = SUCCESS
-    flag = SUCCESS;
+    int flag = SUCCESS;
     // Iterate over all the attributes of the relation
     // Let attrOffset be iterator ranging from 0 to numOfAttributes-1
     {
@@ -420,7 +396,7 @@ int BlockAccess::insert(int relId, Attribute *record) {
         }
     }
 
-    //	return flag;
+    return flag;
 }
 ```
 
@@ -449,50 +425,44 @@ This method changes the relation name of specified relation to the new name spec
 
 ```cpp
 int BlockAccess::renameRelation(char oldName[ATTR_SIZE], char newName[ATTR_SIZE]){
+    // reset the searchIndex of the relation catalog to {-1, -1} using RelCacheTable::setSearchIndex()
+
     Attribute newRelationName;
-    strcpy(newRelationName.sVal, newName);
 
-    // Reset the Search Index by using RelCacheTable and setting value to {-1, -1}
-    RecId searchIndex = {-1, -1};
-    RelCacheTable::setSearchIndex(RELCAT_RELID, &searchIndex);
-    // search for the relation with name newName in relation catalog using linearSearch()
-    relcat_recid = linearSearch(RELCAT_RELID, "RelName", newRelationName, EQ );
-    // note: newRelationName is of type Attribute (to be constructed from newName)
+    // search if the attribute "RelName" of relation catalog equals(EQ) newRelationName using linearSearch
 
-    // If relation with name newName already exits
-    if(relcat_recid != {-1,-1}){
-        return E_RELEXIST;
-    }
+    // If relation with name newName already exists (result of linearSearch is not {-1, -1})
+    //    return E_RELEXIST;
+
+
+    // reset the searchIndex of the relation catalog to {-1, -1} using RelCacheTable::setSearchIndex()
 
     Attribute oldRelationName;
-    strcpy(oldRelationName.sVal, oldName);
 
-    // Reset the Search Index by using RelCacheTable and setting value to {-1, -1}
-    searchIndex = {-1, -1};
-    RelCacheTable::setSearchIndex(RELCAT_RELID, &searchIndex);
-    // search for the relation with name oldName in relation catalog
-    relcat_recid = linearSearch( ---fill the arguments--- );
+    // search if the attribute "RelName" of relation catalog equals(EQ) oldRelationName
 
-    // If relation with name relName does not exits
-    if(relcat_recid == {-1,-1}) {
-        return E_RELNOTEXIST;
-    }
+    // If relation with name oldName does not exist (result of linearSearch is {-1, -1})
+    //    return E_RELNOTEXIST;
 
-    // get the relation catalog record from the relation catalog (recid of the relation catalog record = relcat_recid)
-    RecBuffer recBuffer = RecBuffer(relcat_recid.block);
-    recBuffer.getRecord(relcat_record, relcat_recid.slot);
-
-    // update the relation catalog record in the relation catalog with relation name newName
-    recBuffer.setRecord(record, relcat_recid.slot);
+    /* get the relation catalog record of the relation to rename using a RecBuffer
+       on the relation catalog [RELCAT_BLOCK] and RecBuffer.getRecord function
+    */
+    // update the relation name attribute in the record with newName. (use RELCAT_REL_NAME_INDEX)
+    // set back the record value using RecBuffer.setRecord
 
     /*
-        update all the attribute catalog entries in the attribute catalog corresponding to the
-          relation with relation name oldName to the relation name newName
+    update all the attribute catalog entries in the attribute catalog corresponding
+    to the relation with relation name oldName to the relation name newName
     */
-    // NOTE: Reset the Search Index by using RelCacheTable and setting value to {-1, -1}
-    searchIndex = {-1, -1};
-    RelCacheTable::setSearchIndex(ATTRCAT_RELID, &searchIndex);
 
+    // reset the searchIndex of the attribute catalog to {-1, -1} using RelCacheTable::setSearchIndex()
+
+    //for i = 0 to numberOfAttributes :
+    //    linearSearch on the attribute catalog for relName = oldRelationName
+    //    get the record using RecBuffer.getRecord
+    //
+    //    update the relName field in the record to newName
+    //    set back the record using RecBuffer.setRecord
 
     return SUCCESS;
 }
@@ -525,54 +495,50 @@ This method changes the name of an attribute/column present in a specified relat
 
 ```cpp
 int BlockAccess::renameAttribute(char relName[ATTR_SIZE], char oldName[ATTR_SIZE], char newName[ATTR_SIZE]) {
-    // Search for the relation with name relName in relation catalog using Linear Search
-    Attribute attrValueRelName;
-    strcpy(attrValueRelName.sVal, relName);
-    RecId searchIndex = {-1, -1};
-    RelCacheTable::setSearchIndex(RELCAT_RELID, &searchIndex);
-    RecId relcatRecId = linearSearch(RELCAT_RELID, "RelName", attrValueRelName, EQ);
 
+    // reset the searchIndex of the relation catalog to {-1, -1} using RelCacheTable::setSearchIndex()
+
+    Attribute relNameAttr;
+
+    // Search for the relation with name relName in relation catalog using Linear Search
     // If relation with name relName does not exits (relcatRecId == {-1,-1})
     //    return E_RELNOTEXIST;
 
     /***
         Iterating over all Attribute Catalog Entry record corresponding to relation to find the required attribute
     ***/
-    // Reset the Search Index by using RelCacheTable and setting value to {-1, -1}
-    searchIndex = {-1, -1};
-    RelCacheTable::setSearchIndex(ATTRCAT_RELID, &searchIndex);
+    // reset the searchIndex of the attribute catalog to {-1, -1} using RelCacheTable::setSearchIndex()
 
-    // Define RecId attrId {-1, -1} - used to check if an attribute of oldName exists or not.
-     RecId attrId{-1, -1};
-    Attribute attrcatEntryRecord[ATTRCAT_NO_ATTRS];
-      while (true) {
-        RecId attrcatEntryRecId = linearSearch(ATTRCAT_RELID, "RelName", relationName, EQ);
+    // declare attrToRenameRecId used to store the attr-cat recId of the attribute to rename
+    RecId attrToRenameRecId{-1, -1};
+    Attribute attrCatEntryRecord[ATTRCAT_NO_ATTRS];
 
-        if (attrcatEntryRecId.block == -1) {
-            break;
-        }
+    while (true) {
+        // linear search on the attribute catalog for RelName = relNameAttr
 
-        // Get the attribute catalog record from the attribute catalog
-        // Hint: instantiate RecBuffer Class with appropriate block number and use getRecord method to store the record into attrcatEntryRecord.
+        // if there are no more attributes left to check (linearSearch returned {-1,-1})
+        //     break;
 
-        // if (strcmp(attrcatEntryRecord[1].sVal, oldName) == 0) attrId = attrcatEntryRecId;
+        // Get the record from the attribute catalog using RecBuffer.getRecord into attrCatEntryRecord
 
-        // if (strcmp(attrcatEntryRecord[1].sVal, newName) == 0) return E_ATTREXIST;
+        // if attrCatEntryRecord.attrName = oldName
+        //     attrToRenameRecId = block and slot of this record
 
+        // if attrCatEntryRecord.attrName = newName
+        //     return E_ATTREXIST;
+    }
 
-      }
+    // if attrToRenameRecId == {-1, -1}
+    //     return E_ATTRNOTEXIST;
 
-    // if (attrId.block == -1) return E_ATTRNOTEXIST;
-
-    // Update the entry corresponding to the attribute in the Attribute Catalog Relation.
-    /* Hint: Instantiate RecBuffer class by passing appropriate block number = attrId.block
-        Get the record corresponding to the entry by using getRecord method by passing attrId.slot
-        as argument.
-        Use setRecord method to set the record back after updating the entry appropriately.
+    /*
+     Update the entry corresponding to the attribute in the Attribute Catalog Relation.
     */
+    // declare a RecBuffer for attrToRenameRecId.block and get the record at attrToRenameRecId.slot
+    // update the AttrName of the record with newName
+    // set back the record with RecBuffer.setRecord
 
-
-    // return SUCCESS
+    return SUCCESS;
 }
 
 ```
@@ -604,146 +570,102 @@ If at any point getHeader(), setHeader(), getRecord(), setRecord(), getSlotMap()
 
 ```cpp
 int BlockAccess::deleteRelation(char relName[ATTR_SIZE]) {
-    /* search for relation with name relName in relation catalog using Linear Search and store the relcatRecId */
-    // Hint: relid is RELCAT_RELID attribute name to search will be "RelName" op = EQ
-    // Also make an Attribute (attrValueRelName) with sval = relName and then pass that as the argument to linear search
-    // NOTE: Reset the Search Index by using RelCacheTable and setting value to {-1, -1} before callign the linearSearch()
-    RecId searchIndex = {-1, -1};
-    RelCacheTable::setSearchIndex(RELCAT_RELID, &searchIndex);
+    // reset the searchIndex of the relation catalog to {-1, -1} using RelCacheTable::setSearchIndex()
 
-    RecId relcatRecId = linearSearch(RELCAT_RELID, "RelName", attrvalRelName, EQ);
+    Attribute relNameAttr;
 
-    // If relation with relName does not exits (relcatRecId == {-1, -1}), return E_RELNOTEXIST
+    //  linearSearch on the relation catalog for RelName = relNameAttr
 
-    // Declare Attribute* relcatEntryRecord to store the relation catalog entry corresponding to the relcat entry.
-    Attribute *relcatEntryRecord;
+    // if the relation does not exist (linearSearch returned {-1, -1})
+    //     return E_RELNOTEXIST
 
-    /* Get the relation catalog entry record corresponding to relation with relName using the relcatRecId */
-    // Hint: instantiate RecBuffer class using relcatRecId.block and then use appropriate class method to get the record.
+    Attribute relCatEntryRecord[RELCAT_NO_ATTRS];
+    // store the relation catalog record corresponding to the relation in relCatEntryRecord using RecBuffer.getRecord
 
     // get the first record block of the relation (firstBlock) using the relation catalog entry record
     // get the number of attributes corresponding to the relation (numAttrs) using the relation catalog entry record
 
-    // Delete all the record blocks of the relation by getting the next record blocks (rblock) from header
-    // and by calling releaseBlock() method
     /*
-        Hint: instantiate a BlockBuffer class object by giving appropriate arguments to constructor
-        (which is block number of the first block),
-        get the header of the block by calling appropriate method of the class to fetch 'next' record block number,
-        delete the existing block and repeat for the next block.
-        Also note that to check if we reached the end either use lastBlock number field for currBlock OR check if nextBlock number is -1
-     */
-    while (true) {
-        // Call releaseBlock()
-
-        // if currBlock == lastBlock || nextBlock == -1, break
-
-        // get the BlockBuffer instance for 'nextBlock'
-
-        // update current and next block numbers
-
-    }
+     Delete all the record blocks of the relation
+    */
+    // for each record block of the relation:
+    //     get block header using BlockBuffer.getHeader
+    //     get the next block from the header (rblock)
+    //     release the block using BlockBuffer.releaseBlock
+    //
+    //     Hint: to know if we reached the end, check if nextBlock = -1
 
     /***
         Deleting attribute catalog entries corresponding the relation and index blocks corresponding to the relation with relName on its attributes
     ***/
-    /*
-       Declare attrcatRecId and attractEntryRecord variables to store
-       record id of the attrcat entry and to store the attrcat entry record respectively.
-       Also make an Attribute (attrValueRelName) with sval = relName and then pass that as the argument to linear search
-     */
-    RecId attrcatRecId;
-    Attribute *attrcatEntryRecord;
-    Attribute attrValueRelName;
-    strcpy(attrValueRelName.sVal, relName);
+    // reset the searchIndex of the attribute catalog to {-1, -1} using RelCacheTable::setSearchIndex()
 
-    // Reset the Search Index by using RelCacheTable and setting value to {-1, -1}
-    searchIndex = {-1, -1};
-    RelCacheTable::setSearchIndex(ATTRCAT_RELID, &searchIndex);
+    while(true) {
+        RecId attrCatRecId;
+        // attrCatRecId = linearSearch on attribute catalog for RelName = relNameAttr
 
-    int numberOfAttributesDeleted = 0;
-    // Iterate over all the attributes corresponding to the relation
-    while (true) {
-        // search for all the attributes corresponding to the relation with relName in attribute catalog
-        attrcatRecId = linearSearch(ATTRCAT_RELID, "RelName", attrValueRelName, EQ);
-        if (attrcatRecId.block == -1 && attrcatRecId.slot == -1) {
-            // No more attributes to iterate over.
-            break;
-        }
+        // if no more attributes to iterate over (attrCatRecId == {-1, -1})
+        //     break;
 
-        numberOfAttributesDeleted++;
+        // create a RecBuffer for attrCatRecId.block
+        // get the header of the block
+        // get the record corresponding to attrCatRecId.slot
 
-        /***
-            Deleting the attribute catalog entry corresponding to the attribute from attribute catalog
-        ***/
-
-        // Get the header by Instantiating a RecBuffer instance (attrcatRecBuffer) and calling appropriate methods
-        RecBuffer attrcatRecBuffer = RecBuffer(attrcatRecId.block);
-        HeadInfo attrcatRecBufferBlockHeader;
-        int ret = attrcatRecBuffer.getHeader(&attrcatRecBufferBlockHeader);
-
-        // get the rootBlock from attribute catalog (use attrcatRecBuffer object to call appropriate method
-        // to get record corresponding to the attribute catalog entry)
+        // get root block from the attribute catalog record.
         // This will be used later to delete any indexes if it exists
-        attrcatRecBuffer.getRecord(attrcatEntryRecord, attrcatRecId.slot);
-        int rootBlock = (int) attrcatEntryRecord[ATTRCAT_ROOT_BLOCK_INDEX].nVal;
+        int rootBlock;
 
-        // Update the Slotmap for the block by indicating the slot as free(use SLOT_UNOCCUPIED)
-        slotMap[attrcatRecId.slot] = SLOT_UNOCCUPIED;
+        // Update the Slotmap for the block by indicating the slot as SLOT_UNOCCUPIED
+        // Hint: use RecBuffer.getSlotMap and RecBuffer.setSlotMap
 
-        // Adjust the number of entries in the block (decrease by 1) corresponding to the attribute catalog entry
-                // and set it back using setHeader()
+        // Decrement the numEntries in the header of the block corresponding to the attribute catalog entry
+        // set back the header using RecBuffer.setHeader
 
         // If number of entries become 0, releaseBlock is called after fixing the Linked List.
         // Hint: Update to the linked list involves setting the left and right pointers of block
         // adjacent to the released block appropriately.
-        if (attrcatRecBufferBlockHeader.numEntries == 0) {
+        if (/*   header.numEntries == 0  */) {
             /* Standard Linked List Delete for a Block */
-            // Get the header of the previous block (left block)
-            // Hint: instantiate a RecBuffer class corresponding to the lblock and call appropriate methods
+            // Get the header of the left block and set it's rblock to this block's rblock
+            // create a RecBuffer for lblock and call appropriate methods
 
-            // Set the previous header's rblock to the block's header's rblock
-
-            if (attrcatRecBufferBlockHeader.rblock != -1) {
-                // Get the header of the next block (right block)
-                // Hint: instantiate a RecBuffer class corresponding to the lblock and call appropriate methods
-
-                // Set the next block's header's lblock to the block's header's lblock
+            if (/* header.rblock != -1 */) {
+                // Get the header of the right block and set it's lblock to this block's lblock
+                // create a RecBuffer for rblock and call appropriate methods
 
             } else {
-                // the block being released is the "Last Block" of the relation.
-                // Update the Relation Catalog entry's LastBlock field for this relation with the block number of the previous block.
+                // (the block being released is the "Last Block" of the relation.)
+                // update the Relation Catalog entry's LastBlock field for this relation with the block number of the previous block.
             }
 
-            // call releaseBlock()
+            // (no need to check for empty lblock since attr catalog will never be empty)
 
+            // call releaseBlock()
         }
 
         // if index exists for the attribute (rootBlock != -1), call bplus destroy
         if (rootBlock != -1) {
-            // bplus_destroy(rootBlock); //delete the index blocks corresponding to the attribute
+            // TODO update after bplus
+            // bplus_destroy(rootBlock);
         }
     }
 
     /*** Delete the relation catalog entry corresponding to the relation from relation catalog ***/
     // Fetch the header of Relcat block
 
-    // Adjust the number of entries in the header of the block (decrease by 1) corresponding to the relation catalog entry
-        // and set it back
+    // Decrement the numEntries in the header of the block corresponding to the relation catalog entry and set it back
 
-    // Get the slotmap in relation catalog, update it by marking the slot as free(use SLOT_UNOCCUPIED) and set it back.
+    // Get the slotmap in relation catalog, update it by marking the slot as free(SLOT_UNOCCUPIED) and set it back.
 
     /*** Updating the Relation Cache Table ***/
     /** Update relation catalog record entry (number of records in relation catalog is decreased by 1) **/
-    // Hint: Get the entry corresponding to relation catalog from the relation cache and update the number of records
-    // and set it back
+    // Hint: Get the entry corresponding to relation catalog from the relation cache and update the number of records and set it back
 
     /** Update attribute catalog entry (number of records in attribute catalog is decreased by numberOfAttributesDeleted) **/
-    i.e., #Records = #Records - numberOfAttributesDeleted
+    // i.e., #Records = #Records - numberOfAttributesOfRelation
 
-    // Hint: Get the entry corresponding to attribute catalog from the relation cache and update the number of records
-    // and set it back
+    // Hint: Get the entry corresponding to attribute catalog from the relation cache and update the number of records and set it back
 
-    // return SUCCESS;
+    return SUCCESS;
 }
 ```

--- a/docs/Design/Block Access Layer.md
+++ b/docs/Design/Block Access Layer.md
@@ -94,7 +94,7 @@ RecId BlockAccess::linearSearch(int relId, char attrName[ATTR_SIZE], union Attri
     }
     else
     {
-        //	(there is a hit from previous search; search should start from the record next to the search index record)
+        // (there is a hit from previous search; search should start from the record next to the search index record)
 
         // block = search index's block
         // slot = search index's slot + 1
@@ -308,10 +308,10 @@ int BlockAccess::insert(int relId, Attribute *record) {
         // update blockNum = header.rblock (next element in the linked list of record blocks)
     }
 
-    //	if no free slot is found in existing record blocks
+    //  if no free slot is found in existing record blocks
     {
         // if relation is RELCAT, do not allocate any more blocks (i.e. if relId = RELCAT_RELID)
-        //	    return E_MAXRELATIONS;
+        //     return E_MAXRELATIONS;
 
         // Otherwise,
         // get a new record block by calling RecBuffer Constructor for new block

--- a/docs/Design/Cache Layer.md
+++ b/docs/Design/Cache Layer.md
@@ -197,6 +197,7 @@ public:
     static int setRelCatEntry(int relId, RelCatEntry *relCatBuf);
     static int getSearchIndex(int relId, RecId *searchIndex);
     static int setSearchIndex(int relId, RecId *searchIndex);
+    static int resetSearchIndex(int relId);
 
 private:
     //field
@@ -397,6 +398,37 @@ int RelCacheTable::setSearchIndex(int relId, recId *searchIndex) {
 
     return SUCCESS;
 
+}
+```
+
+### RelCacheTable :: resetSearchIndex
+
+#### Description
+
+Resets the value of `searchIndex` field of the given relation in _Relation Cache_ Table to {-1, -1}. This is used so that the linear search can be restarted from the first record.
+
+#### Arguments
+
+| Name  | Type  | Description                                                   |
+| ----- | ----- | ------------------------------------------------------------- |
+| relId | `int` | The relation id of the relation in the _Relation Cache_ Table |
+
+#### Return Values
+
+| Value                        | Description                                                                                                                                 |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`SUCCESS`](/constants)      | Successfully copied the _Relation Catalog_ entry                                                                                            |
+| [`E_OUTOFBOUND`](/constants) | Input relId is outside the valid set of possible relation ids                                                                               |
+| [`E_NOTOPEN`](/constants)    | Entry corresponding to input relId is free in the _Relation Cache_ Table. Use OpenRelTable::openRel() to load the relation to cache memory. |
+
+#### Algorithm
+
+```cpp
+int RelCacheTable::resetSearchIndex(int relId) {
+
+    // declare a RecId having value {-1, -1}
+    // set the search index to {-1, -1} using RelCacheTable::setSearchIndex
+    // return the value returned by setSearchIndex
 }
 ```
 

--- a/src/pages/constants.md
+++ b/src/pages/constants.md
@@ -3,10 +3,10 @@
 The constants used by various algorithms in NITCbase documentation are listed in the files errors.h(error values returned by the algorithms described in the project documentation) and constants.h(other global constants)
 
 ## constants.h
+
 ```cpp
 #ifndef NITCBASE_CONSTANTS_H
 #define NITCBASE_CONSTANTS_H
-#include <iostream>
 
 // Path to disk
 #define DISK_PATH "../Disk/disk"
@@ -109,11 +109,7 @@ The constants used by various algorithms in NITCbase documentation are listed in
 // Greater than
 #define GT 105
 // Not equal to
-#define NE 106 //if considered
-// Reset Operator (used to reset the previous hit's search index)
-#define RST 100 //reset op.
-// Project Operator (used for project operation)
-#define PRJCT 107
+#define NE 106  // if considered
 
 // Data types
 // For an Integer or a Floating point number
@@ -141,29 +137,29 @@ The constants used by various algorithms in NITCbase documentation are listed in
 // Index for the Relation Name attribute of a relation catalog entry
 #define RELCAT_REL_NAME_INDEX 0
 // Index for the #Attributes attribute of a relation catalog entry
-#define	RELCAT_NO_ATTRIBUTES_INDEX 1
+#define RELCAT_NO_ATTRIBUTES_INDEX 1
 // Index for the #Records attribute of a relation catalog entry
-#define	RELCAT_NO_RECORDS_INDEX 2
+#define RELCAT_NO_RECORDS_INDEX 2
 // Index for the First Block attribute of a relation catalog entry
-#define	RELCAT_FIRST_BLOCK_INDEX 3
+#define RELCAT_FIRST_BLOCK_INDEX 3
 // Index for the Last Block attribute of a relation catalog entry
-#define	RELCAT_LAST_BLOCK_INDEX 4
+#define RELCAT_LAST_BLOCK_INDEX 4
 // Index for the Number of slots per block attribute of a relation catalog entry
-#define	RELCAT_NO_SLOTS_PER_BLOCK_INDEX 5
+#define RELCAT_NO_SLOTS_PER_BLOCK_INDEX 5
 
 // Indexes for Attribute Catalog Attributes
 // Index for Relation Name attribute of an attribute catalog entry
 #define ATTRCAT_REL_NAME_INDEX 0
 // Index for Attribute Name attribute of an attribute catalog entry
-#define	ATTRCAT_ATTR_NAME_INDEX 1
+#define ATTRCAT_ATTR_NAME_INDEX 1
 // Index for Attribute Type attribute of an attribute catalog entry
-#define	ATTRCAT_ATTR_TYPE_INDEX 2
+#define ATTRCAT_ATTR_TYPE_INDEX 2
 // Index for Primary Flag attribute of an attribute catalog entry
-#define	ATTRCAT_PRIMARY_FLAG_INDEX 3
+#define ATTRCAT_PRIMARY_FLAG_INDEX 3
 // Index for Root Block attribute of an attribute catalog entry
-#define	ATTRCAT_ROOT_BLOCK_INDEX 4
+#define ATTRCAT_ROOT_BLOCK_INDEX 4
 // Index for Offset attribute of an attribute catalog entry
-#define	ATTRCAT_OFFSET_INDEX 5
+#define ATTRCAT_OFFSET_INDEX 5
 
 // Global variables for B+ Tree Layer
 // Maximum number of keys allowed in an Internal Node of a B+ tree
@@ -174,6 +170,10 @@ The constants used by various algorithms in NITCbase documentation are listed in
 #define MAX_KEYS_LEAF 63
 // Index of the middle element in a Leaf Node of a B+ tree
 #define MIDDLE_INDEX_LEAF 31
+
+// Name strings for Relation Catalog and Attribute Catalog (as it is stored in the Relation catalog)
+#define RELCAT_RELNAME "RELATIONCAT"
+#define ATTRCAT_RELNAME "ATTRIBUTECAT"
 
 // Relation Catalog attribute name strings
 #define RELCAT_ATTR_RELNAME "RelName"
@@ -194,5 +194,5 @@ The constants used by various algorithms in NITCbase documentation are listed in
 #define SET 1
 #define UNSET 0
 
-#endif //NITCBASE_CONSTANTS_H
+#endif  // NITCBASE_CONSTANTS_H
 ```


### PR DESCRIPTION
The designs of this layer was unnecessarily verbose, especially for renameRelation and renameAttribute which is mostly just code. I have rewritten them to be better representative of the core algorithm. The new designs and the specific changes are mentioned below
Additionally, the project method has been added and reset has been handled in the block access layer. these function calls have been updated throughout

## linearSearch
- minor corrections and additions
- replaced a switch statement with the same case body throughout with an if statement checking for all the required equalities and conditions
- updated the comments to reflect the above change
- removed the PRJCT operator and moved that functionality to project function

## search
- removed the RST and PRJCT operators. reset is now handled in RelCacheTable::resetSearchIndex and project in the project method.

## renameAttribute
- reworded the docs and replaced a lot of code with the necessary descriptions

## deleteRelation
- rewrote the docs to be less verbose
- for deleting the record blocks, the existing design would call releaseBlock even if there were no record blocks for the relation. fixed that.
- in the above case, for seeing if we were at the last record block the old design would allow checking for currBlock == lastBlock OR nextBlock == -1. the first case would have been an infinite loop in the case of no record blocks.

## project
- the project operation is now handled here. all functions have been updated to match this schema.
