### PR TITLE
Update B+ Tree Layer.md

### DIFF
--- a/docs/Design/B+ Tree Layer.md
+++ b/docs/Design/B+ Tree Layer.md
@@ -109,6 +109,9 @@ int BPlusTree::bPlusCreate(int relId, char attrName[ATTR_SIZE]) {
         return E_DISKFULL;
     }
 
+      // update the rootBlock of attribute catalog cache entry to rootBlock using
+     // AttrCacheTable::setAttrCatEntry().
+
     RelCatEntry relCatEntry;
 
     // load the relation catalog entry into relCatEntry


### PR DESCRIPTION
fixed error in the documentation in BPlusTree::bPlusCreate,it was creating a new leaf block since it was updating in the attribute catalog it can't insert index